### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,5 +71,4 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
           yarn
-          yarn build
-          npm publish ./dist
+          npm publish


### PR DESCRIPTION
package.json is written to perform the build before packing for publishing, and
we are not just publishing dist (there is no package.json in that). This is the
simplest config anyway, and it actually works.