### PR TITLE
Set template verison to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-template",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "A JupiterOne Integration",
   "license": "MPL-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
Running `yarn version` when the template version was 1.0.0 causes the _initial_ package version to be > 1.0.0. Devs can work around this by manually changing the `package.json` version to pre-1.0.0 before running `yarn version`. but it's not a great workflow or very intuitive for first deploys.