### PR TITLE
Improve consistency of /dist dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,4 +64,5 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
           yarn
-          npm publish
+          yarn build
+          npm publish ./dist

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "description": "A JupiterOne Integration",
   "license": "MPL-2.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
   "files": [
-    "dist"
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -21,9 +21,8 @@
     "test": "jest",
     "test:env": "LOAD_ENV=1 yarn test",
     "test:ci": "yarn lint && yarn type-check && yarn test",
-    "build": "tsc -p tsconfig.dist.json --declaration",
-    "prepush": "yarn lint && yarn type-check && jest --changedSince master",
-    "prepack": "yarn build"
+    "build": "tsc -p tsconfig.dist.json --declaration && cp README.md dist/README.md",
+    "prepush": "yarn lint && yarn type-check && jest --changedSince master"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^6.0.0"
@@ -32,5 +31,8 @@
     "@jupiterone/integration-sdk-core": "^6.0.0",
     "@jupiterone/integration-sdk-dev-tools": "^6.0.0",
     "@jupiterone/integration-sdk-testing": "^6.0.0"
+  },
+  "dependencies": {
+    "uuid": "^8.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
     "@jupiterone/integration-sdk-core": "^6.0.0",
     "@jupiterone/integration-sdk-dev-tools": "^6.0.0",
     "@jupiterone/integration-sdk-testing": "^6.0.0"
-  },
-  "dependencies": {
-    "uuid": "^8.3.2"
   }
 }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,10 +1,13 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"],
+  "include": ["src", "package.json"],
   "exclude": [
     "dist",
     "**/*.test.ts",
+    "**/*.test.js",
     "**/*/__tests__/**/*.ts",
-    "**/*/__mocks__/**/*.ts"
+    "**/*/__tests__/**/*.js",
+    "**/*/__tests__/**/*.ts",
+    "**/*/__tests__/**/*.js"
   ]
 }


### PR DESCRIPTION
We recently saw in https://github.com/JupiterOne/graph-tenable-cloud/pull/106 that when a project references the `package.json` as code, tsc automagically restructures the `/dist` directory like:
```
package.json
src/
  index.ts
  ...
dist/
  package.json
  src/
    index.js
    index.d.ts
    ...
...
```

While without that magic, it packages files as
```
package.json
src/
  index.ts
  ...
dist/
  index.js
  index.d.ts
  ...
```

This updates our build config & build process to always and consistently publish exactly the following in our distributions:

```
package.json
README.md
src/
  index.js
  index.d.ts
  ...
```