### PR TITLE
adding create release steps that fail nicely

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
           then
             echo "Found version commit tag. Publishing."
             echo "publish=true" >> $GITHUB_ENV
+            echo "VERSION_NUM=`echo $(git describe --tags --abbrev=0 | sed -e "s/v//gI")`" >> $GITHUB_ENV
           else
             echo "Version commit tag not found. Not publishing."
           fi
@@ -66,3 +67,28 @@ jobs:
           yarn
           yarn build
           npm publish ./dist
+
+      - name: Get Version Changelog Entry
+        if: env.publish == 'true'
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ env.VERSION_NUM }}
+          path: ./CHANGELOG.md
+        continue-on-error: true
+
+      - name: Create Release
+        if: env.publish == 'true'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # This pulls from the "Get Changelog Entry" step above, referencing it's ID to get its outputs object.
+          # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          tag_name: ${{ steps.changelog_reader.outputs.version }}
+          release_name: Release ${{ steps.changelog_reader.outputs.version }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
+          draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
+        continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # This pulls from the "Get Changelog Entry" step above, referencing it's ID to get its outputs object.
-          # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           tag_name: ${{ steps.changelog_reader.outputs.version }}
           release_name: Release ${{ steps.changelog_reader.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }}


### PR DESCRIPTION
This is something we talked about and I wanted to mess around with github actions. This will trigger on a version publish and parse the changelog file to create a release with that information. I added a flag to `continue-on-error` which will not fail the job if the steps for the release creation fails. Figured for now that's fine.

One change that needs to happen with how we do changelogs is the versioning is expected to have brackets:

`## 0.0.2 - 2021-08-04` ---> `## [0.0.2] - 2021-08-04`

This will fail if it is not in this format.

Would be cool if we could somehow apply this to the entire changelog to get all the old stuff, but didn't look into that.

I forked a repo to show what this looks like:

* This is a failing example, notice the job still has a green checkmark despite the failure for the steps(Create Release/Version Changelog): https://github.com/ceelias/graph-knowbe4/runs/3248131293?check_suite_focus=true

* This is what the release looks like: https://github.com/ceelias/graph-knowbe4/releases