### PR TITLE
Update validateInvocation tests to use recordings

### DIFF
--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -1,13 +1,9 @@
 import {
-  IntegrationProviderAuthenticationError,
-  IntegrationValidationError,
-} from '@jupiterone/integration-sdk-core';
-import {
   createMockExecutionContext,
   Recording,
-  setupRecording,
 } from '@jupiterone/integration-sdk-testing';
 import { integrationConfig } from '../test/config';
+import { setupProjectRecording } from '../test/recording';
 import { IntegrationConfig, validateInvocation } from './config';
 
 describe('#validateInvocation', () => {
@@ -19,48 +15,21 @@ describe('#validateInvocation', () => {
     }
   });
 
-  it('requires valid config', async () => {
+  test('requires valid config', async () => {
     const executionContext = createMockExecutionContext<IntegrationConfig>({
       instanceConfig: {} as IntegrationConfig,
     });
 
     await expect(validateInvocation(executionContext)).rejects.toThrow(
-      IntegrationValidationError,
+      'Config requires all of {clientId, clientSecret}',
     );
   });
 
   /**
-   * Testing authorizations can be done with recordings.
-   * To capture failed responses, recordFailedRequests is set to true.
+   * Testing a successful authorization can be done with recordings
    */
-  it.skip('auth error', async () => {
-    recording = setupRecording({
-      directory: __dirname,
-      name: 'client-auth-error',
-      // Many authorization failures will return non-200 responses
-      // and `recordFailedRequest: true` is needed to capture these responses
-      options: {
-        recordFailedRequests: true,
-      },
-    });
-
-    const executionContext = createMockExecutionContext({
-      instanceConfig: {
-        clientId: 'INVALID',
-        clientSecret: 'INVALID',
-      },
-    });
-
-    await expect(validateInvocation(executionContext)).rejects.toThrow(
-      IntegrationProviderAuthenticationError,
-    );
-  });
-
-  /**
-   * Testing a successful authorization can be done with recordings as well
-   */
-  it.skip('validates invocation', async () => {
-    recording = setupRecording({
+  test.skip('successfully validates invocation', async () => {
+    recording = setupProjectRecording({
       directory: __dirname,
       name: 'validate-invocation',
     });
@@ -72,5 +41,64 @@ describe('#validateInvocation', () => {
 
     // successful validateInvocation doesn't throw errors and will be undefined
     await expect(validateInvocation(executionContext)).resolves.toBeUndefined();
+  });
+
+  /* Adding `describe` blocks segments the tests into logical sections
+   * and makes the output of `yarn test --verbose` provide meaningful
+   * to project information to future maintainers.
+   */
+  describe('fails validating invocation', () => {
+    /**
+     * Testing failing authorizations can be done with recordings as well.
+     * For each possible failure case, a test can be made to ensure that
+     * error messaging is expected and clear to end-users
+     */
+    describe('invalid user credentials', () => {
+      test.skip('should throw if clientId is invalid', async () => {
+        recording = setupProjectRecording({
+          directory: __dirname,
+          name: 'client-id-auth-error',
+          // Many authorization failures will return non-200 responses
+          // and `recordFailedRequest: true` is needed to capture these responses
+          options: {
+            recordFailedRequests: true,
+          },
+        });
+
+        const executionContext = createMockExecutionContext({
+          instanceConfig: {
+            clientId: 'INVALID',
+            clientSecret: integrationConfig.clientSecret,
+          },
+        });
+
+        // tests validate that invalid configurations throw an error
+        // with an appropriate and expected message.
+        await expect(validateInvocation(executionContext)).rejects.toThrow(
+          'Provider authentication failed at https://localhost/api/v1/some/endpoint?limit=1: 401 Unauthorized',
+        );
+      });
+
+      test.skip('should throw if clientSecret is invalid', async () => {
+        recording = setupProjectRecording({
+          directory: __dirname,
+          name: 'client-secret-auth-error',
+          options: {
+            recordFailedRequests: true,
+          },
+        });
+
+        const executionContext = createMockExecutionContext({
+          instanceConfig: {
+            clientId: integrationConfig.clientSecret,
+            clientSecret: 'INVALID',
+          },
+        });
+
+        await expect(validateInvocation(executionContext)).rejects.toThrow(
+          'Provider authentication failed at https://localhost/api/v1/some/endpoint?limit=1: 401 Unauthorized',
+        );
+      });
+    });
   });
 });

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -4,38 +4,73 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import {
   createMockExecutionContext,
+  Recording,
   setupRecording,
 } from '@jupiterone/integration-sdk-testing';
+import { integrationConfig } from '../test/config';
 import { IntegrationConfig, validateInvocation } from './config';
 
-it('requires valid config', async () => {
-  const executionContext = createMockExecutionContext<IntegrationConfig>({
-    instanceConfig: {} as IntegrationConfig,
+describe('#validateInvocation', () => {
+  let recording: Recording;
+
+  afterEach(async () => {
+    if (recording) {
+      await recording.stop();
+    }
   });
 
-  await expect(validateInvocation(executionContext)).rejects.toThrow(
-    IntegrationValidationError,
-  );
-});
+  it('requires valid config', async () => {
+    const executionContext = createMockExecutionContext<IntegrationConfig>({
+      instanceConfig: {} as IntegrationConfig,
+    });
 
-it('auth error', async () => {
-  const recording = setupRecording({
-    directory: '__recordings__',
-    name: 'client-auth-error',
+    await expect(validateInvocation(executionContext)).rejects.toThrow(
+      IntegrationValidationError,
+    );
   });
 
-  recording.server.any().intercept((req, res) => {
-    res.status(401);
+  /**
+   * Testing authorizations can be done with recordings.
+   * To capture failed responses, recordFailedRequests is set to true.
+   */
+  it.skip('auth error', async () => {
+    recording = setupRecording({
+      directory: __dirname,
+      name: 'client-auth-error',
+      // Many authorization failures will return non-200 responses
+      // and `recordFailedRequest: true` is needed to capture these responses
+      options: {
+        recordFailedRequests: true,
+      },
+    });
+
+    const executionContext = createMockExecutionContext({
+      instanceConfig: {
+        clientId: 'INVALID',
+        clientSecret: 'INVALID',
+      },
+    });
+
+    await expect(validateInvocation(executionContext)).rejects.toThrow(
+      IntegrationProviderAuthenticationError,
+    );
   });
 
-  const executionContext = createMockExecutionContext({
-    instanceConfig: {
-      clientId: 'INVALID',
-      clientSecret: 'INVALID',
-    },
-  });
+  /**
+   * Testing a successful authorization can be done with recordings as well
+   */
+  it.skip('validates invocation', async () => {
+    recording = setupRecording({
+      directory: __dirname,
+      name: 'validate-invocation',
+    });
 
-  await expect(validateInvocation(executionContext)).rejects.toThrow(
-    IntegrationProviderAuthenticationError,
-  );
+    // Pass integrationConfig to authenticate with real credentials
+    const executionContext = createMockExecutionContext({
+      instanceConfig: integrationConfig,
+    });
+
+    // successful validateInvocation doesn't throw errors and will be undefined
+    await expect(validateInvocation(executionContext)).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
# Description

This PR changes  the `validateInvocation` tests to use examples that make use of recordings rather than `recording.server.any.intercept()`.

The use of `intercept` contributed to the error seen in https://github.com/JupiterOne/graph-rumble/pull/9. This change brings in examples based on the `validateInvocation` tests used in [graph-rumble](https://github.com/JupiterOne/graph-rumble).

One downside to this is that there isn't a way to have the tests work out of the box without altering `client.verifyAuthentication()` to have logic that wouldn't provide a good example. I have opted to `skip` these test to include but not run them.

If anyone has thoughts about how these tests might run under the given constraints, they'd be appreciated!