### PR TITLE
Add .j1-integration-cache to .gitignore and .prettierignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .j1-integration/
+.j1-integration-cache/
 .env
 .eslintcache
 tsconfig.tsbuildinfo

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 dist
 coverage/
 .j1-integration
+.j1-integration-cache
 .gitleaks.yml


### PR DESCRIPTION
# Description

Add .j1-integration-cache to .gitignore and .prettierignore so future repos can auto ignore this folder.

