### PR TITLE
Flip checkout and node setup steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,16 +36,16 @@ jobs:
     if: github.ref == 'refs/heads/main'
     name: Checkout Code
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
-          cache: yarn
       - name: Check out repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
           token: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
       - name: Build and Release
         uses: jupiterone/action-npm-build-release@v1
         with:


### PR DESCRIPTION
# Description

A build error was reoccurring where the dependency lock file was not found. It appears with cache: yarn, the repo needs to be checked out first.
